### PR TITLE
Fix for "Too many files open" bug

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -28,6 +28,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "raygesualdo",
+      "name": "Ray Gesualdo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5465958?v=3",
+      "profile": "https://www.raygesualdo.com",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A tool to help generate code for workshop repositories
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -192,8 +192,8 @@ I am unaware of other solutions. Feel free to submit a PR if you know of similar
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/split-guide/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/split-guide/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/split-guide/commits?author=kentcdodds) 💡 | [<img src="https://avatars.githubusercontent.com/u/193238?v=3" width="100px;"/><br /><sub>Jack Franklin</sub>](http://www.jackfranklin.co.uk)<br />[📖](https://github.com/kentcdodds/split-guide/commits?author=jackfranklin) |
-| :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/split-guide/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/split-guide/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/split-guide/commits?author=kentcdodds) 💡 | [<img src="https://avatars.githubusercontent.com/u/193238?v=3" width="100px;"/><br /><sub>Jack Franklin</sub>](http://www.jackfranklin.co.uk)<br />[📖](https://github.com/kentcdodds/split-guide/commits?author=jackfranklin) | [<img src="https://avatars.githubusercontent.com/u/5465958?v=3" width="100px;"/><br /><sub>Ray Gesualdo</sub>](https://www.raygesualdo.com)<br />[💻](https://github.com/kentcdodds/split-guide/commits?author=raygesualdo) |
+| :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!


### PR DESCRIPTION
The error raised in #3 occurs when there's a lot of files that `split-guide` has to read. I found the number for small files to be somewhere between 1000 and 10,000 (the number changes based on system resources available and file size). To solve this, I wrote a utility function that takes all of the files that need to be opened, chunks them out into smaller groups, runs `Promise.all` on each of the chunks serially, then returns the whole set. I've tested this with an exercise set of 10,000 files and it works great. I tried 100,000 files and Node completely crashed on me with an out of memory exception, but hopefully no one will ever use this with that many files :)