### PR TITLE
Feat: Allow valid CSS and HTML comment syntax

### DIFF
--- a/src/bin/__tests__/__snapshots__/index.js.snap
+++ b/src/bin/__tests__/__snapshots__/index.js.snap
@@ -623,6 +623,14 @@ This is common stuff
     "file": "<projectRootDir>/test/fixtures/generate/exercises/foo/bar/README.md",
   },
   Object {
+    "contents": "body {
+    /* Normal CSS Comment */
+    font-family: sans-serif;
+}
+",
+    "file": "<projectRootDir>/test/fixtures/generate/exercises/root.css",
+  },
+  Object {
     "contents": "/* eslint-disable */
 module.exports = function sum(a, b) {
   // return the sum of a and b
@@ -649,6 +657,13 @@ This is final stuff
 because the result is an empty string for the exercises directory
 ",
     "file": "<projectRootDir>/test/fixtures/generate/exercises-final/foo/final-only.md",
+  },
+  Object {
+    "contents": "body {
+    font-family: Arial, sans-serif;
+}
+",
+    "file": "<projectRootDir>/test/fixtures/generate/exercises-final/root.css",
   },
   Object {
     "contents": "/* eslint-disable */
@@ -687,6 +702,12 @@ Object {
           "size": 65,
         },
         Object {
+          "extension": ".css",
+          "name": "root.css",
+          "path": "<projectRootDir>/test/fixtures/generate/exercises/root.css",
+          "size": 67,
+        },
+        Object {
           "extension": ".js",
           "name": "root.js",
           "path": "<projectRootDir>/test/fixtures/generate/exercises/root.js",
@@ -695,7 +716,7 @@ Object {
       ],
       "name": "exercises",
       "path": "<projectRootDir>/test/fixtures/generate/exercises",
-      "size": 157,
+      "size": 224,
     },
     Object {
       "children": Array [
@@ -726,6 +747,12 @@ Object {
           "size": 170,
         },
         Object {
+          "extension": ".css",
+          "name": "root.css",
+          "path": "<projectRootDir>/test/fixtures/generate/exercises-final/root.css",
+          "size": 45,
+        },
+        Object {
           "extension": ".js",
           "name": "root.js",
           "path": "<projectRootDir>/test/fixtures/generate/exercises-final/root.js",
@@ -734,7 +761,7 @@ Object {
       ],
       "name": "exercises-final",
       "path": "<projectRootDir>/test/fixtures/generate/exercises-final",
-      "size": 246,
+      "size": 291,
     },
     Object {
       "children": Array [
@@ -765,6 +792,12 @@ Object {
           "size": 524,
         },
         Object {
+          "extension": ".css",
+          "name": "root.css",
+          "path": "<projectRootDir>/test/fixtures/generate/templates/root.css",
+          "size": 280,
+        },
+        Object {
           "extension": ".js",
           "name": "root.js",
           "path": "<projectRootDir>/test/fixtures/generate/templates/root.js",
@@ -773,20 +806,22 @@ Object {
       ],
       "name": "templates",
       "path": "<projectRootDir>/test/fixtures/generate/templates",
-      "size": 785,
+      "size": 1065,
     },
   ],
   "name": "generate",
   "path": "<projectRootDir>/test/fixtures/generate",
-  "size": 1188,
+  "size": 1580,
 }
 `;
 
 exports[`generate in <projectRootDir>/test/fixtures/generate stdout 1`] = `
-"Saved 5 files:
+"Saved 7 files:
 <projectRootDir>/test/fixtures/generate/exercises/foo/bar/README.md
 <projectRootDir>/test/fixtures/generate/exercises-final/foo/bar/README.md
 <projectRootDir>/test/fixtures/generate/exercises-final/foo/final-only.md
+<projectRootDir>/test/fixtures/generate/exercises/root.css
+<projectRootDir>/test/fixtures/generate/exercises-final/root.css
 <projectRootDir>/test/fixtures/generate/exercises/root.js
 <projectRootDir>/test/fixtures/generate/exercises-final/root.js"
 `;

--- a/src/bin/__tests__/__snapshots__/index.js.snap
+++ b/src/bin/__tests__/__snapshots__/index.js.snap
@@ -623,9 +623,26 @@ This is common stuff
     "file": "<projectRootDir>/test/fixtures/generate/exercises/foo/bar/README.md",
   },
   Object {
+    "contents": "<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+    <meta charset=\\"UTF-8\\">
+    <title>Test</title>
+</head>
+<body>
+    <h1>Workshop</h1>
+
+
+    <p>Everywhere</p>
+</body>
+</html>
+",
+    "file": "<projectRootDir>/test/fixtures/generate/exercises/index.html",
+  },
+  Object {
     "contents": "body {
-    /* Normal CSS Comment */
-    font-family: sans-serif;
+  /* Normal CSS Comment */
+  font-family: sans-serif;
 }
 ",
     "file": "<projectRootDir>/test/fixtures/generate/exercises/root.css",
@@ -659,8 +676,25 @@ because the result is an empty string for the exercises directory
     "file": "<projectRootDir>/test/fixtures/generate/exercises-final/foo/final-only.md",
   },
   Object {
+    "contents": "<!DOCTYPE html>
+<html lang=\\"en\\">
+<head>
+    <meta charset=\\"UTF-8\\">
+    <title>Test</title>
+</head>
+<body>
+
+    <h1>Final</h1>
+
+    <p>Everywhere</p>
+</body>
+</html>
+",
+    "file": "<projectRootDir>/test/fixtures/generate/exercises-final/index.html",
+  },
+  Object {
     "contents": "body {
-    font-family: Arial, sans-serif;
+  font-family: Arial, sans-serif;
 }
 ",
     "file": "<projectRootDir>/test/fixtures/generate/exercises-final/root.css",
@@ -702,10 +736,16 @@ Object {
           "size": 65,
         },
         Object {
+          "extension": ".html",
+          "name": "index.html",
+          "path": "<projectRootDir>/test/fixtures/generate/exercises/index.html",
+          "size": 168,
+        },
+        Object {
           "extension": ".css",
           "name": "root.css",
           "path": "<projectRootDir>/test/fixtures/generate/exercises/root.css",
-          "size": 67,
+          "size": 63,
         },
         Object {
           "extension": ".js",
@@ -716,7 +756,7 @@ Object {
       ],
       "name": "exercises",
       "path": "<projectRootDir>/test/fixtures/generate/exercises",
-      "size": 224,
+      "size": 388,
     },
     Object {
       "children": Array [
@@ -747,10 +787,16 @@ Object {
           "size": 170,
         },
         Object {
+          "extension": ".html",
+          "name": "index.html",
+          "path": "<projectRootDir>/test/fixtures/generate/exercises-final/index.html",
+          "size": 165,
+        },
+        Object {
           "extension": ".css",
           "name": "root.css",
           "path": "<projectRootDir>/test/fixtures/generate/exercises-final/root.css",
-          "size": 45,
+          "size": 43,
         },
         Object {
           "extension": ".js",
@@ -761,7 +807,7 @@ Object {
       ],
       "name": "exercises-final",
       "path": "<projectRootDir>/test/fixtures/generate/exercises-final",
-      "size": 291,
+      "size": 454,
     },
     Object {
       "children": Array [
@@ -792,10 +838,16 @@ Object {
           "size": 524,
         },
         Object {
+          "extension": ".html",
+          "name": "index.html",
+          "path": "<projectRootDir>/test/fixtures/generate/templates/index.html",
+          "size": 336,
+        },
+        Object {
           "extension": ".css",
           "name": "root.css",
           "path": "<projectRootDir>/test/fixtures/generate/templates/root.css",
-          "size": 280,
+          "size": 266,
         },
         Object {
           "extension": ".js",
@@ -806,20 +858,22 @@ Object {
       ],
       "name": "templates",
       "path": "<projectRootDir>/test/fixtures/generate/templates",
-      "size": 1065,
+      "size": 1387,
     },
   ],
   "name": "generate",
   "path": "<projectRootDir>/test/fixtures/generate",
-  "size": 1580,
+  "size": 2229,
 }
 `;
 
 exports[`generate in <projectRootDir>/test/fixtures/generate stdout 1`] = `
-"Saved 7 files:
+"Saved 9 files:
 <projectRootDir>/test/fixtures/generate/exercises/foo/bar/README.md
 <projectRootDir>/test/fixtures/generate/exercises-final/foo/bar/README.md
 <projectRootDir>/test/fixtures/generate/exercises-final/foo/final-only.md
+<projectRootDir>/test/fixtures/generate/exercises/index.html
+<projectRootDir>/test/fixtures/generate/exercises-final/index.html
 <projectRootDir>/test/fixtures/generate/exercises/root.css
 <projectRootDir>/test/fixtures/generate/exercises-final/root.css
 <projectRootDir>/test/fixtures/generate/exercises/root.js

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import {getErrorLogger} from './utils'
 
 // We need to escape \ when used with constructor
 // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
-const CommentStartTpl = '(?:\\/\\/\\s|\\/\\*\\s?)'
+const CommentStartTpl = '(?:\\/\\/\\s|\\/\\*\\s?|<!--\\s?)'
 const CommentEndTpl = '.*?\\n'
 
 const getRegEx = entity =>

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,11 @@ import pify from 'pify'
 import pLimit from 'p-limit'
 import {getErrorLogger} from './utils'
 
-const CommentStartTpl = `\/\/ `
-const CommentEndTpl = `.*?\n`
+// We need to escape \ when used with constructor
+// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
+const CommentStartTpl = '(?:\\/\\/\\s|\\/\\*\\s?)'
+const CommentEndTpl = '.*?\\n'
+
 const getRegEx = entity =>
   ` *?${CommentStartTpl}${entity}_START${CommentEndTpl}((.|\n|\r)*?) *${CommentStartTpl}${entity}_END${CommentEndTpl}`
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,18 +7,27 @@ import pify from 'pify'
 import pLimit from 'p-limit'
 import {getErrorLogger} from './utils'
 
+const CommentStartTpl = `\/\/ `
+const CommentEndTpl = `.*?\n`
+const getRegEx = entity =>
+  ` *?${CommentStartTpl}${entity}_START${CommentEndTpl}((.|\n|\r)*?) *${CommentStartTpl}${entity}_END${CommentEndTpl}`
+
 const REGEX = {
-  final: / *?\/\/ FINAL_START.*?\n((.|\n|\r)*?) *\/\/ FINAL_END.*?\n/g,
-  workshop: / *?\/\/ WORKSHOP_START.*?\n((.|\n|\r)*?) *\/\/ WORKSHOP_END.*?\n/g,
-  comment: / *?\/\/ COMMENT_START.*?\n((.|\n|\r)*?) *\/\/ COMMENT_END.*?\n/g,
+  final: new RegExp(getRegEx('FINAL'), 'g'),
+  workshop: new RegExp(getRegEx('WORKSHOP'), 'g'),
+  comment: new RegExp(getRegEx('COMMENT'), 'g'),
 }
 const openFileLimit = pLimit(100)
 
 export default splitGuide
 
-function splitGuide(
-  {templatesDir, exercisesDir, exercisesFinalDir, clean, ignore} = {},
-) {
+function splitGuide({
+  templatesDir,
+  exercisesDir,
+  exercisesFinalDir,
+  clean,
+  ignore,
+} = {}) {
   return deletePreviouslyGeneratedFiles()
     .then(getFiles)
     .then(readAllFilesAsPromise)

--- a/test/fixtures/generate/templates/index.html
+++ b/test/fixtures/generate/templates/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test</title>
+</head>
+<body>
+<!--WORKSHOP_START-->
+    <h1>Workshop</h1>
+<!--WORKSHOP_END-->
+
+<!--FINAL_START-->
+    <h1>Final</h1>
+<!--FINAL_END-->
+
+<!--COMMENT_START-->
+<!--This is an HTML comment-->
+<!--COMMENT_END-->
+    <p>Everywhere</p>
+</body>
+</html>

--- a/test/fixtures/generate/templates/root.css
+++ b/test/fixtures/generate/templates/root.css
@@ -1,0 +1,12 @@
+/* COMMENT_START */
+/*this is the top of the CSS file, and it has comments*/
+/* COMMENT_END */
+body {
+  /*WORKSHOP_START*/
+  /* Normal CSS Comment */
+  font-family: sans-serif;
+  /*WORKSHOP_END*/
+  /*FINAL_START*/
+  font-family: Arial, sans-serif;
+  /*FINAL_END*/
+}


### PR DESCRIPTION
At the moment, there is no way to create CSS or HTML files with a valid syntax as a template since the tool only supports comments starting with `//`. This PR adds `/*` and `<!--` as valid comment starting tokens.

It also refactors RegExp generation bit to make it more easy to add new comment tokens.